### PR TITLE
Fixed gray ptr bug

### DIFF
--- a/fifo/afifo_assim/afifo_assim_tb.v
+++ b/fifo/afifo_assim/afifo_assim_tb.v
@@ -108,11 +108,11 @@ module afifo_assim_tb;
        read=1;
 `ifdef WR_RATIO
        //Read all the locations of RAM.
-       for(i=0; i < `WR_RATIO*(2**`W_ADDR_W)-1; i = i + 1) begin
+       for(i=0; i < `WR_RATIO*((2**`W_ADDR_W)-1); i = i + 1) begin
            // Result will only be available in the next cycle
            @(posedge rclk) #1;
-	  if(data_out != i/`WR_RATIO*((i%`WR_RATIO)==0) || level_r != ((2**`W_ADDR_W)*`WR_RATIO-2)-i) begin
-               $display("Test failed: read error in data_out.\n \t i=%0d; data=%0d", i, data_out);
+	  if(data_out != i/`WR_RATIO*((i%`WR_RATIO)==0) || level_r != (((2**`W_ADDR_W)-1)*`WR_RATIO)-1-i) begin
+               $display("Test failed: read error in data_out.\n \t i=%0d; data=%0d; exp=%0d; lvl=%0d, levl=%0d", i, data_out, i/`WR_RATIO*((i%`WR_RATIO)==0), (((2**`W_ADDR_W)-1)*`WR_RATIO)-i, level_r);
                // $finish;
            end
        end


### PR DESCRIPTION
Now gray pointers are synchronized to the other clock domain,
converted to bin
and multiplied by the respective factor according to W_ADDR_W/R_ADDR_W ratios

Updated testbench