### PR TITLE
Gray2bin module

### DIFF
--- a/hardware/fifo/afifo/hardware.mk
+++ b/hardware/fifo/afifo/hardware.mk
@@ -2,5 +2,7 @@
 include $(MEM_HW_DIR)/ram/t2p_ram/hardware.mk
 
 # Sources
+FIFO_DIR=$(MEM_HW_DIR)/fifo
 AFIFO_DIR=$(MEM_HW_DIR)/fifo/afifo
 VSRC+=$(AFIFO_DIR)/iob_async_fifo.v
+VSRC+=$(FIFO_DIR)/gray2bin.v

--- a/hardware/fifo/afifo/iob_async_fifo.v
+++ b/hardware/fifo/afifo/iob_async_fifo.v
@@ -53,28 +53,16 @@ module iob_async_fifo
    wire [ADDRESS_WIDTH-1:0]     wptr;
    reg [ADDRESS_WIDTH-1:0]      rptr_sync[1:0];
    wire                         write_en_int;
+   wire [ADDRESS_WIDTH-1:0]     wptr_bin_w;
+   wire [ADDRESS_WIDTH-1:0]     rptr_bin_w;
    
    //READ DOMAIN    
    wire [ADDRESS_WIDTH-1:0]     rptr;
    reg [ADDRESS_WIDTH-1:0]      wptr_sync[1:0];
    wire                         read_en_int;
+   wire [ADDRESS_WIDTH-1:0]     wptr_bin_r;
+   wire [ADDRESS_WIDTH-1:0]     rptr_bin_r;
 
-   //convert gray to binary code
-   function [ADDRESS_WIDTH-1:0] gray2bin;
-      input reg [ADDRESS_WIDTH-1:0] gr;
-      input integer                 N;
-      begin: g2b
-   reg [ADDRESS_WIDTH-1:0] bi;
-   integer                 i;
-   
-   bi[N-1] = gr[N-1];
-   for (i=N-2;i>=0;i=i-1)
-           bi[i] = gr[i] ^ bi[i+1];
-   
-   gray2bin = bi;
-      end
-   endfunction
-   
    //WRITE DOMAIN LOGIC
 
    //sync read pointer
@@ -93,7 +81,19 @@ module iob_async_fifo
                                                .data_out(wptr)
                                                );
    //compute binary pointer difference
-   assign level_w = gray2bin(wptr, ADDRESS_WIDTH) - gray2bin(rptr_sync[1], ADDRESS_WIDTH);
+   gray2bin #(
+       .DATA_W(ADDRESS_WIDTH)
+   ) gray2bin_wptr_w (
+       .gr(wptr),
+       .bin(wptr_bin_w)
+   );
+   gray2bin #(
+       .DATA_W(ADDRESS_WIDTH)
+   ) gray2bin_rptr_w (
+       .gr(rptr_sync[1]),
+       .bin(rptr_bin_w)
+   );
+   assign level_w = wptr_bin_w - rptr_bin_w;
    
    assign full = (level_w == (FIFO_DEPTH-1));
 
@@ -117,23 +117,33 @@ module iob_async_fifo
                                               );
    
    //compute binary pointer difference
-   assign level_r = gray2bin(wptr_sync[1], ADDRESS_WIDTH) - gray2bin(rptr, ADDRESS_WIDTH);
+   gray2bin #(
+       .DATA_W(ADDRESS_WIDTH)
+   ) gray2bin_wptr_r (
+       .gr(wptr_sync[1]),
+       .bin(wptr_bin_r)
+   );
+   gray2bin #(
+       .DATA_W(ADDRESS_WIDTH)
+   ) gray2bin_rptr_r (
+       .gr(rptr),
+       .bin(rptr_bin_r)
+   );
+   assign level_r = wptr_bin_r - rptr_bin_r;
    
 
    assign empty = (level_r == 0);
 
    iob_t2p_ram #(
-            .W_DATA_W(DATA_WIDTH),
-            .W_ADDR_W(ADDRESS_WIDTH),
-            .R_DATA_W(DATA_WIDTH),
-            .R_ADDR_W(ADDRESS_WIDTH)
+            .DATA_W(DATA_WIDTH),
+            .ADDR_W(ADDRESS_WIDTH)
             ) fifo_t2p_ram (
                 .wclk(wclk),
                 .w_en(write_en_int),
                 .w_data(w_data),
-                .w_addr(gray2bin(wptr, ADDRESS_WIDTH)),
+                .w_addr(wptr_bin_w),
                 .rclk(rclk),
-                .r_addr(gray2bin(rptr, ADDRESS_WIDTH)),
+                .r_addr(rptr_bin_r),
                 .r_en(read_en_int),
                 .r_data(r_data)
                 );

--- a/hardware/fifo/afifo_asym/hardware.mk
+++ b/hardware/fifo/afifo_asym/hardware.mk
@@ -2,5 +2,7 @@
 include $(MEM_HW_DIR)/ram/t2p_asym_ram/hardware.mk
 
 # Sources
+FIFO_DIR=$(MEM_HW_DIR)/fifo
 AFIFO_ASYM_DIR=$(MEM_HW_DIR)/fifo/afifo_asym
 VSRC+=$(AFIFO_ASYM_DIR)/iob_async_fifo_asym.v
+VSRC+=$(FIFO_DIR)/gray2bin.v

--- a/hardware/fifo/afifo_asym/iob_async_fifo_asym_tb.v
+++ b/hardware/fifo/afifo_asym/iob_async_fifo_asym_tb.v
@@ -3,8 +3,10 @@
 `define DATA_W 8
 `define ADDR_W 4
 
+// define RW_RATIO or WR_RATIO
 // `define RW_RATIO 4
-// `define WR_RATIO 4
+`define WR_RATIO 4
+
 `ifdef WR_RATIO
  `define W_DATA_W (`DATA_W*`WR_RATIO)
  `define R_DATA_W (`DATA_W)

--- a/hardware/fifo/gray2bin.v
+++ b/hardware/fifo/gray2bin.v
@@ -1,0 +1,24 @@
+`timescale 1ns/1ps
+
+// Convert gray encoding to binary
+module gray2bin #(
+    parameter DATA_W = 4
+    ) (
+    input [DATA_W-1:0] gr,
+    output [DATA_W-1:0] bin
+    );
+
+    reg [DATA_W-1:0]  bi;
+    integer 	        i;
+    integer 		    N = DATA_W;
+
+    always @* begin
+        bi[N-1] = gr[N-1];
+        for (i=N-2;i>=0;i=i-1)
+           bi[i] = gr[i] ^ bi[i+1];
+    end
+
+    assign bin = bi;
+
+endmodule
+

--- a/hardware/ram/t2p_asym_ram/iob_t2p_asym_ram.v
+++ b/hardware/ram/t2p_asym_ram/iob_t2p_asym_ram.v
@@ -41,7 +41,7 @@ module iob_t2p_asym_ram
     	end
     	else if (W_DATA_W == R_DATA_W)
 	  begin
-	     iob_2p_ram #(
+	     iob_t2p_ram #(
 				.DATA_W(W_DATA_W),
 				.ADDR_W(W_ADDR_W)
 				) two_port_ram (


### PR DESCRIPTION
- Add gray2bin module
- Use gray2bin module for fifos instead of functions
- This reduces the syntax features from verilog that we use
- Requires less sofisticated parsing for some tools, for example the covered coverage analyzer
- Changes pass module testbenches
- Note: I can open an issue and perform a PR to a new branch if necessary