### PR TITLE
Update hardware.mk for remaining modules; Minor fix for quartus synthesis

### DIFF
--- a/hardware/fifo/iob_fifo_sync/hardware.mk
+++ b/hardware/fifo/iob_fifo_sync/hardware.mk
@@ -3,13 +3,10 @@ ifneq (iob_fifo_sync,$(filter iob_fifo_sync, $(HW_MODULES)))
 # Add to modules list
 HW_MODULES+=iob_fifo_sync
 
-# Paths
-SFIFO_DIR=$(MEM_FIFO_DIR)/iob_fifo_sync
-
 # Submodules
-include $(MEM_RAM_DIR)/iob_ram_2p_asym/hardware.mk
+include $(MEM_DIR)/hardware/ram/iob_ram_2p_asym/hardware.mk
 
 # Sources
-VSRC+=$(SFIFO_DIR)/iob_fifo_sync.v
+VSRC+=$(MEM_DIR)/hardware/fifo/iob_fifo_sync/iob_fifo_sync.v
 
 endif

--- a/hardware/ram/iob_ram_2p/hardware.mk
+++ b/hardware/ram/iob_ram_2p/hardware.mk
@@ -4,11 +4,8 @@ ifneq (iob_ram_2p,$(filter $S, $(HW_MODULES)))
 # Add to modules list
 HW_MODULES+=iob_ram_2p
 
-# Paths
-2PRAM_DIR=$(MEM_RAM_DIR)/iob_ram_2p
-
 # Sources
-VSRC+=$(2PRAM_DIR)/iob_ram_2p.v
+VSRC+=$(MEM_DIR)/hardware/ram/iob_ram_2p/iob_ram_2p.v
 
 endif
 endif

--- a/hardware/ram/iob_ram_2p_asym/hardware.mk
+++ b/hardware/ram/iob_ram_2p_asym/hardware.mk
@@ -4,14 +4,11 @@ ifneq (iob_ram_2p_asym,$(filter iob_ram_2p_asym,, $(HW_MODULES)))
 # Add to modules list
 HW_MODULES+=iob_ram_2p_asym
 
-# Paths
-2P_ASYM_RAM_DIR=$(MEM_RAM_DIR)/iob_ram_2p_asym
-
 # Submodules
-include $(MEM_RAM_DIR)/iob_ram_2p/hardware.mk
+include $(MEM_DIR)/hardware/ram/iob_ram_2p/hardware.mk
 
 # Sources
-VSRC+=$(2P_ASYM_RAM_DIR)/iob_ram_2p_asym.v
+VSRC+=$(MEM_DIR)/hardware/ram/iob_ram_2p_asym/iob_ram_2p_asym.v
 
 endif
 endif

--- a/hardware/ram/iob_ram_2p_asym/iob_ram_2p_asym.v
+++ b/hardware/ram/iob_ram_2p_asym/iob_ram_2p_asym.v
@@ -45,7 +45,7 @@ module iob_ram_2p_asym
    //instantiate N symmetric RAM blocks and connect them to the buses
    genvar                 i;
    generate
-      for (i=0; i<N; i=i+1) begin
+      for (i=0; i<N; i=i+1) begin : iob_2p_ram_inst
          iob_ram_2p
              #(
                .DATA_W(MINDATA_W),

--- a/hardware/ram/iob_ram_2p_tiled/hardware.mk
+++ b/hardware/ram/iob_ram_2p_tiled/hardware.mk
@@ -4,14 +4,11 @@ ifneq (iob_ram_2p_tiled,$(filter iob_ram_2p_tiled,, $(HW_MODULES)))
 # Add to modules list
 HW_MODULES+=iob_ram_2p_tiled
 
-# Paths
-2PRAM_TILED_DIR=$(MEM_RAM_DIR)/iob_ram_2p_tiled
-
 # Submodules
-include $(MEM_RAM_DIR)/iob_ram_2p/hardware.mk
+include $(MEM_DIR)/hardware/ram/iob_ram_2p/hardware.mk
 
 # Sources
-VSRC+=$(2PRAM_TILED_DIR)/iob_ram_2p_tiled.v
+VSRC+=$(MEM_DIR)/hardware/ram/iob_ram_2p_tiled/iob_ram_2p_tiled.v
 
 endif
 endif

--- a/hardware/ram/iob_ram_dp/hardware.mk
+++ b/hardware/ram/iob_ram_dp/hardware.mk
@@ -4,11 +4,8 @@ ifneq (iob_ram_dp,$(filter iob_ram_dp,, $(HW_MODULES)))
 # Add to modules list
 HW_MODULES+=iob_ram_dp
 
-# Paths
-DPRAM_DIR=$(MEM_RAM_DIR)/iob_ram_dp
-
 # Sources
-VSRC+=$(DPRAM_DIR)/iob_ram_dp.v
+VSRC+=$(MEM_DIR)/hardware/ram/iob_ram_dp/iob_ram_dp.v
 
 endif
 endif

--- a/hardware/ram/iob_ram_dp_be/hardware.mk
+++ b/hardware/ram/iob_ram_dp_be/hardware.mk
@@ -4,14 +4,11 @@ ifneq (iob_ram_dp_be,$(filter iob_ram_dp_be,, $(HW_MODULES)))
 # Add to modules list
 HW_MODULES+=iob_ram_dp_be
 
-# Paths
-DPRAM_BE_DIR=$(MEM_RAM_DIR)/iob_ram_dp_be
-
 # Submodules
-include $(MEM_RAM_DIR)/iob_ram_dp/hardware.mk
+include $(MEM_DIR)/hardware/ram/iob_ram_dp/hardware.mk
 
 # Sources
-VSRC+=$(DPRAM_BE_DIR)/iob_ram_dp_be.v
+VSRC+=$(MEM_DIR)/hardware/ram/iob_ram_dp_be/iob_ram_dp_be.v
 
 endif
 endif

--- a/hardware/ram/iob_ram_sp/hardware.mk
+++ b/hardware/ram/iob_ram_sp/hardware.mk
@@ -4,11 +4,8 @@ ifneq (iob_ram_sp,$(filter iob_ram_sp,, $(HW_MODULES)))
 # Add to modules list
 HW_MODULES+=iob_ram_sp
 
-# Paths
-SPRAM_DIR=$(MEM_RAM_DIR)/iob_ram_sp
-
 # Sources
-VSRC+=$(SPRAM_DIR)/iob_ram_sp.v
+VSRC+=$(MEM_DIR)/hardware/ram/iob_ram_sp/iob_ram_sp.v
 
 endif
 endif

--- a/hardware/ram/iob_ram_sp_be/hardware.mk
+++ b/hardware/ram/iob_ram_sp_be/hardware.mk
@@ -4,14 +4,11 @@ ifneq (iob_ram_sp_be,$(filter $S, $(HW_MODULES)))
 # Add to modules list
 HW_MODULES+=iob_ram_sp_be
 
-# Paths
-SPRAM_BE_DIR=$(MEM_RAM_DIR)/iob_ram_sp_be
-
 # Submodules
-include $(MEM_RAM_DIR)/iob_ram_sp/hardware.mk
+include $(MEM_DIR)/hardware/ram/iob_ram_sp/hardware.mk
 
 # Sources
-VSRC+=$(SPRAM_BE_DIR)/iob_ram_sp_be.v
+VSRC+=$(MEM_DIR)/hardware/ram/iob_ram_sp_be/iob_ram_sp_be.v
 
 endif
 endif

--- a/hardware/ram/iob_ram_tdp/hardware.mk
+++ b/hardware/ram/iob_ram_tdp/hardware.mk
@@ -4,11 +4,8 @@ ifneq (iob_ram_tdp,$(filter iob_ram_tdp,, $(HW_MODULES)))
 # Add to modules list
 HW_MODULES+=iob_ram_tdp
 
-# Paths
-TDPRAM_DIR=$(MEM_RAM_DIR)/iob_ram_tdp
-
 # Sources
-VSRC+=$(TDPRAM_DIR)/iob_ram_tdp.v
+VSRC+=$(MEM_DIR)/hardware/ram/iob_ram_tdp/iob_ram_tdp.v
 
 endif
 endif

--- a/hardware/ram/iob_ram_tdp_be/hardware.mk
+++ b/hardware/ram/iob_ram_tdp_be/hardware.mk
@@ -4,14 +4,11 @@ ifneq (iob_ram_tdp_be,$(filter $S, $(HW_MODULES)))
 # Add to modules list
 HW_MODULES+=iob_ram_tdp_be
 
-# Paths
-TDPRAM_BE_DIR=$(MEM_RAM_DIR)/iob_ram_tdp_be
-
 # Submodules
-include $(MEM_RAM_DIR)/iob_ram_tdp/hardware.mk
+include $(MEM_DIR)/hardware/ram/iob_ram_tdp/hardware.mk
 
 # Sources
-VSRC+=$(TDPRAM_BE_DIR)/iob_ram_tdp_be.v
+VSRC+=$(MEM_DIR)/hardware/ram/iob_ram_tdp_be/iob_ram_tdp_be.v
 
 endif
 endif

--- a/hardware/regfile/iob_regfile_dp/hardware.mk
+++ b/hardware/regfile/iob_regfile_dp/hardware.mk
@@ -4,11 +4,8 @@ ifneq (iob_regfile_dp,$(filter iob_regfile_dp,, $(HW_MODULES)))
 # Add to modules list
 HW_MODULES+=iob_regfile_dp
 
-# Paths
-DP_REGFILE_DIR=$(MEM_REGF_DIR)/iob_regfile_dp
-
 # Sources
-VSRC+=$(DP_REGFILE_DIR)/iob_regfile_dp.v
+VSRC+=$(MEM_DIR)/hardware/regfile/iob_regfile_dp/iob_regfile_dp.v
 
 endif
 endif

--- a/hardware/regfile/iob_regfile_sp/hardware.mk
+++ b/hardware/regfile/iob_regfile_sp/hardware.mk
@@ -4,11 +4,8 @@ ifneq (iob_regfile_sp,$(filter iob_regfile_sp,, $(HW_MODULES)))
 # Add to modules list
 HW_MODULES+=iob_regfile_sp
 
-# Paths
-SP_REGFILE_DIR=$(MEM_REGF_DIR)/iob_regfile_sp
-
 # Sources
-VSRC+=$(SP_REGFILE_DIR)/iob_regfile_sp.v
+VSRC+=$(MEM_DIR)/hardware/regfile/iob_regfile_sp/iob_regfile_sp.v
 
 endif
 endif

--- a/hardware/rom/iob_rom_dp/hardware.mk
+++ b/hardware/rom/iob_rom_dp/hardware.mk
@@ -4,11 +4,8 @@ ifneq (iob_rom_dp,$(filter $S, $(HW_MODULES)))
 # Add to modules list
 HW_MODULES+=iob_rom_dp
 
-# Paths
-DPROM_DIR=$(MEM_ROM_DIR)/iob_rom_dp
-
 # Sources
-VSRC+=$(DPROM_DIR)/iob_rom_dp.v
+VSRC+=$(MEM_DIR)/hardware/rom/iob_rom_dp/iob_rom_dp.v
 
 endif
 endif

--- a/hardware/rom/iob_rom_sp/hardware.mk
+++ b/hardware/rom/iob_rom_sp/hardware.mk
@@ -4,11 +4,8 @@ ifneq (iob_rom_sp,$(filter iob_rom_sp, $(HW_MODULES)))
 # Add to modules list
 HW_MODULES+=iob_rom_sp
 
-# Paths
-SPROM_DIR=$(MEM_ROM_DIR)/iob_rom_sp
-
 # Sources
-VSRC+=$(SPROM_DIR)/iob_rom_sp.v
+VSRC+=$(MEM_DIR)/hardware/rom/iob_rom_sp/iob_rom_sp.v
 
 endif
 endif

--- a/hardware/rom/iob_rom_tdp/hardware.mk
+++ b/hardware/rom/iob_rom_tdp/hardware.mk
@@ -4,11 +4,8 @@ ifneq (iob_rom_tdp,$(filter iob_rom_tdp,, $(HW_MODULES)))
 # Add to modules list
 HW_MODULES+=iob_rom_tdp
 
-# Paths
-TDPROM_DIR=$(MEM_ROM_DIR)/iob_rom_tdp
-
 # Sources
-VSRC+=$(TDPROM_DIR)/iob_rom_tdp.v
+VSRC+=$(MEM_DIR)/hardware/rom/iob_rom_tdp/iob_rom_tdp.v
 
 endif
 endif


### PR DESCRIPTION
- Update hardware.mk for remaining modules to only use `MEM_DIR` variable
- Add block name to for generate, this solves error in quartus synthesis