### PR TITLE
fix(python): Fix python scripts shebang

### DIFF
--- a/software/python/hex_split.py
+++ b/software/python/hex_split.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import string
 from sys import argv

--- a/software/python/makehex.py
+++ b/software/python/makehex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from sys import argv
 

--- a/software/python/memwrapper.py
+++ b/software/python/memwrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 


### PR DESCRIPTION
Fix python scripts shebang to use `/usr/bin/env` interpreter instead
of system interpreter.
This uses the first python3 interpreter in `$PATH` instead of the
hardcoded `/usr/bin/python3` system interpreter. This change is needed
if we want to run the python scripts from a virtual environment for
example.
- Check: [this post](https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my/29620#29620) for more information